### PR TITLE
Fix function name

### DIFF
--- a/Assets/Scripts/SQL3/SQL3_Login.cs
+++ b/Assets/Scripts/SQL3/SQL3_Login.cs
@@ -45,7 +45,7 @@ namespace sql3
         // Update is called once per frame
         void Update()
         {
-            UserNotLoggedIn();
+            VerifyUserLogin();
 
             CheckUsername();
 
@@ -53,7 +53,7 @@ namespace sql3
         }
 
         #region Is the User Logged In?
-        void UserNotLoggedIn()
+        void VerifyUserLogin()
         {
             if (!userLoggedIn)
             {


### PR DESCRIPTION
Following the clear code standards it's necessary that method names have verbs that we don't see in "UserNotLoggedIn". The best option is to call the "VerifyUserLogin" method.